### PR TITLE
Fix incorrect header import in view controller

### DIFF
--- a/Example/MHTOOL/MHViewController.m
+++ b/Example/MHTOOL/MHViewController.m
@@ -7,7 +7,7 @@
 //
 
 #import "MHViewController.h"
-#import <MHPerson.h>
+#import <MHTOOL/MHPerson.h>
 @interface MHViewController ()
 
 @end


### PR DESCRIPTION
## Summary
- use proper MHTOOL module path for MHPerson import in example view controller

## Testing
- `xcodebuild test -project Example/MHTOOL.xcodeproj -scheme MHTOOL-Example` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aebfa9e6dc83239f7feaff2a3a4355